### PR TITLE
Egress lockdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,19 @@ init:
 	terraform init
 
 create: init
-	terraform plan -out aro.plan \
+	terraform plan -out aro.plan 		\
 		-var "cluster_name=aro-${USER}" \
 
 	terraform apply aro.plan
+
+create-private: init
+	terraform plan -out aro.plan 		\
+		-var "cluster_name=aro-${USER}" \
+		-var "egress_lockdown=true"		\
+		-var "aro_private=true"
+
+	terraform apply aro.plan
+
 
 destroy:
 	terraform destroy

--- a/egress.tf
+++ b/egress.tf
@@ -1,0 +1,57 @@
+resource "azurerm_virtual_network" "firewall_vnet" {
+  count               = var.egress_lockdown ? 1 : 0
+  name                = "${local.name_prefix}-fw-vnet"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  address_space       = [var.aro_virtual_network_cidr_block]
+  tags                = var.tags
+}
+
+resource "azurerm_subnet" "firewall_subnet" {
+  count                = var.egress_lockdown ? 1 : 0
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.firewall_vnet.0.name
+  address_prefixes     = [var.aro_control_subnet_cidr_block]
+  service_endpoints    = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
+}
+
+resource "azurerm_public_ip" "firewall_ip" {
+  count               = var.egress_lockdown ? 1 : 0
+  name                = "${local.name_prefix}-fw-ip"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+
+}
+
+resource "azurerm_firewall" "firewall" {
+  count               = var.egress_lockdown ? 1 : 0
+  name                = "${local.name_prefix}-firewall"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
+
+  ip_configuration {
+    name                 = "${local.name_prefix}-fw-ip-config"
+    subnet_id            = azurerm_subnet.firewall_subnet.0.id
+    public_ip_address_id = azurerm_public_ip.firewall_ip.0.id
+  }
+
+}
+
+resource "azurerm_route_table" "firewall_rt" {
+  name                = "${local.name_prefix}-fw-rt"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  route {
+    name           = "${local.name_prefix}-udr"
+    address_prefix = "0.0.0.0/0"
+    next_hop_type  = "VirtualAppliance"
+  }
+  tags = var.tags
+
+}

--- a/egress.tf
+++ b/egress.tf
@@ -72,17 +72,18 @@ resource "azurerm_route_table" "firewall_rt" {
 }
 
 resource "azurerm_firewall_network_rule_collection" "firewall_app_rules" {
-  name                = "testcollection"
-  azure_firewall_name = azurerm_firewall.firewall.name
+  count               = var.egress_lockdown ? 1 : 0
+  name                = "${local.name_prefix}-fw-network-rules"
+  azure_firewall_name = azurerm_firewall.firewall.0.name
   resource_group_name = azurerm_resource_group.main.name
   priority            = 100
   action              = "Allow"
 
   rule {
-    name = "Allow_Egress"
+    name = "allow-all"
 
     source_addresses = [
-      "10.0.0.0/16",
+      "*",
     ]
 
     destination_ports = [

--- a/jumphost.tf
+++ b/jumphost.tf
@@ -1,0 +1,7 @@
+resource "azurerm_subnet" "jumphost" {
+  name                 = "${local.name_prefix}-jumphost-subnet"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.aro_jumphost_subnet_cidr_block]
+  service_endpoints    = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
+}

--- a/jumphost.tf
+++ b/jumphost.tf
@@ -1,7 +1,112 @@
-resource "azurerm_subnet" "jumphost" {
+resource "azurerm_subnet" "jumphost-subnet" {
+  count                = var.aro_private ? 1 : 0
   name                 = "${local.name_prefix}-jumphost-subnet"
   resource_group_name  = azurerm_resource_group.main.name
   virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = [var.aro_jumphost_subnet_cidr_block]
-  service_endpoints    = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
+  service_endpoints    = ["Microsoft.ContainerRegistry"]
+
+}
+
+# Due to remote-exec issue Static allocation needs
+# to be used - https://github.com/hashicorp/terraform/issues/21665
+resource "azurerm_public_ip" "jumphost-pip" {
+  count               = var.aro_private ? 1 : 0
+  name                = "${local.name_prefix}-jumphost-pip"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  allocation_method   = "Static"
+  tags                = var.tags
+
+}
+
+resource "azurerm_network_interface" "jumphost-nic" {
+  count               = var.aro_private ? 1 : 0
+  name                = "${local.name_prefix}-jumphost-nic"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.jumphost-subnet.0.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.jumphost-pip.0.id
+  }
+  tags = var.tags
+}
+
+resource "azurerm_network_security_group" "jumphost-nsg" {
+  count               = var.aro_private ? 1 : 0
+  name                = "${local.name_prefix}-jumphost-nsg"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+
+  security_rule {
+    name                       = "allow_ssh_sg"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "association" {
+  count                     = var.aro_private ? 1 : 0
+  network_interface_id      = azurerm_network_interface.jumphost-nic.0.id
+  network_security_group_id = azurerm_network_security_group.jumphost-nsg.0.id
+}
+
+resource "azurerm_linux_virtual_machine" "jumphost-vm" {
+  count               = var.aro_private ? 1 : 0
+  name                = "${local.name_prefix}-jumphost"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  size                = "Standard_D2s_v3"
+  admin_username      = "aro"
+
+  network_interface_ids = [
+    azurerm_network_interface.jumphost-nic.0.id,
+  ]
+
+  admin_ssh_key {
+    username   = "aro"
+    public_key = file("~/.ssh/id_rsa.pub")
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "RedHat"
+    offer     = "RHEL"
+    sku       = "8.2"
+    version   = "8.2.2021040911"
+  }
+
+  provisioner "remote-exec" {
+    connection {
+      type = "ssh"
+      host = azurerm_public_ip.jumphost-pip.0.ip_address
+      user = "aro"
+    }
+    inline = [
+      "sudo dnf install telnet wget bash-completion -y",
+      "wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz",
+      "tar -xvf openshift-client-linux.tar.gz",
+      "sudo mv oc kubectl /usr/bin/",
+      "oc completion bash > oc_bash_completion",
+      "sudo cp oc_bash_completion /etc/bash_completion.d/"
+    ]
+  }
+
+  tags = var.tags
+}
+
+output "public_ip" {
+  value = azurerm_public_ip.jumphost-pip.0.ip_address
 }

--- a/main.tf
+++ b/main.tf
@@ -39,60 +39,61 @@ resource "azurerm_subnet" "machine_subnet" {
 
 # ## ARO Cluster
 
-# ## ARO Public mode (Default)
-# resource "azureopenshift_redhatopenshift_cluster" "cluster" {
-#   count               = var.aro_private ? 0 : 1
-#   name                = var.cluster_name
-#   location            = azurerm_resource_group.main.location
-#   resource_group_name = azurerm_resource_group.main.name
-#   tags                = var.tags
-#   master_profile {
-#     subnet_id = azurerm_subnet.control_plane_subnet.id
-#   }
-#   worker_profile {
-#     subnet_id = azurerm_subnet.machine_subnet.id
-#   }
-#   service_principal {
-#     client_id     = azuread_application.cluster.application_id
-#     client_secret = azuread_application_password.cluster.value
-#   }
-#   depends_on = [
-#     azurerm_subnet.machine_subnet,
-#     azurerm_subnet.control_plane_subnet,
-#     azurerm_role_assignment.vnet
-#   ]
-# }
+## ARO Public mode (Default)
+resource "azureopenshift_redhatopenshift_cluster" "cluster" {
+  count               = var.aro_private ? 0 : 1
+  name                = var.cluster_name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
+  master_profile {
+    subnet_id = azurerm_subnet.control_plane_subnet.id
+  }
+  worker_profile {
+    subnet_id = azurerm_subnet.machine_subnet.id
+  }
+  service_principal {
+    client_id     = azuread_application.cluster.application_id
+    client_secret = azuread_application_password.cluster.value
+  }
+  depends_on = [
+    azurerm_subnet.machine_subnet,
+    azurerm_subnet.control_plane_subnet,
+    azurerm_role_assignment.vnet
+  ]
+}
 
-# ## ARO Private mode
-# resource "azureopenshift_redhatopenshift_cluster" "private" {
-#   count               = var.aro_private ? 1 : 0
-#   name                = var.cluster_name
-#   location            = azurerm_resource_group.main.location
-#   resource_group_name = azurerm_resource_group.main.name
-#   tags                = var.tags
+## ARO Private mode
+resource "azureopenshift_redhatopenshift_cluster" "private" {
+  count               = var.aro_private ? 1 : 0
+  name                = var.cluster_name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
 
-#   master_profile {
-#     subnet_id = azurerm_subnet.control_plane_subnet.id
-#   }
-#   worker_profile {
-#     subnet_id = azurerm_subnet.machine_subnet.id
-#   }
-#   service_principal {
-#     client_id     = azuread_application.cluster.application_id
-#     client_secret = azuread_application_password.cluster.value
-#   }
+  master_profile {
+    subnet_id = azurerm_subnet.control_plane_subnet.id
+  }
+  worker_profile {
+    subnet_id = azurerm_subnet.machine_subnet.id
+  }
+  service_principal {
+    client_id     = azuread_application.cluster.application_id
+    client_secret = azuread_application_password.cluster.value
+  }
 
-#   api_server_profile {
-#     visibility = "VisibilityPrivate"
-#   }
+  api_server_profile {
+    visibility = "Private"
+  }
 
-#   ingress_profile {
-#     visibility = "VisibilityPrivate"
-#   }
+  ingress_profile {
+    visibility = "Private"
+  }
 
-#   depends_on = [
-#     azurerm_subnet.machine_subnet,
-#     azurerm_subnet.control_plane_subnet,
-#     azurerm_role_assignment.vnet
-#   ]
-# }
+  depends_on = [
+    azurerm_subnet.machine_subnet,
+    azurerm_subnet.control_plane_subnet,
+    azurerm_role_assignment.vnet,
+    azurerm_firewall_network_rule_collection.firewall_network_rules
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,59 +1,98 @@
 locals {
-    name_prefix = var.cluster_name
+  name_prefix = var.cluster_name
 }
 
 resource "azurerm_resource_group" "main" {
-    name        = "${local.name_prefix}-rg"
-    location    = var.location
+  name     = "${local.name_prefix}-rg"
+  location = var.location
+
 }
 
 ## Network resources
 resource "azurerm_virtual_network" "main" {
-    name                = "${local.name_prefix}-vnet"
-    location            = azurerm_resource_group.main.location
-    resource_group_name = azurerm_resource_group.main.name
-    address_space       = [var.aro_virtual_network_cidr_block]
-    tags                = var.tags
+  name                = "${local.name_prefix}-vnet"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  address_space       = [var.aro_virtual_network_cidr_block]
+  tags                = var.tags
+
 }
 
 resource "azurerm_subnet" "control_plane_subnet" {
-  name                    = "${local.name_prefix}-cp-subnet"
-  resource_group_name     = azurerm_resource_group.main.name
-  virtual_network_name    = azurerm_virtual_network.main.name
-  address_prefixes        = [var.aro_control_subnet_cidr_block]
-  service_endpoints       = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
-  enforce_private_link_service_network_policies = true
+  name                                           = "${local.name_prefix}-cp-subnet"
+  resource_group_name                            = azurerm_resource_group.main.name
+  virtual_network_name                           = azurerm_virtual_network.main.name
+  address_prefixes                               = [var.aro_control_subnet_cidr_block]
+  service_endpoints                              = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
+  enforce_private_link_service_network_policies  = true
   enforce_private_link_endpoint_network_policies = true
+
 }
 
 resource "azurerm_subnet" "machine_subnet" {
-  name                  = "${local.name_prefix}-machine-subnet"
-  resource_group_name   = azurerm_resource_group.main.name
-  virtual_network_name  = azurerm_virtual_network.main.name
-  address_prefixes      = [var.aro_machine_subnet_cidr_block]
-  service_endpoints     = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
+  name                 = "${local.name_prefix}-machine-subnet"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.aro_machine_subnet_cidr_block]
+  service_endpoints    = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
 }
 
-## ARO Cluster
+# ## ARO Cluster
 
-resource "azureopenshift_redhatopenshift_cluster" "cluster" {
-  name                = var.cluster_name
-  location            = azurerm_resource_group.main.location
-  resource_group_name = azurerm_resource_group.main.name
-  tags                = var.tags
-  master_profile {
-    subnet_id = azurerm_subnet.control_plane_subnet.id
-  }
-  worker_profile {
-    subnet_id = azurerm_subnet.machine_subnet.id
-  }
-  service_principal {
-    client_id     = azuread_application.cluster.application_id
-    client_secret = azuread_application_password.cluster.value
-  }
-  depends_on = [
-    azurerm_subnet.machine_subnet,
-    azurerm_subnet.control_plane_subnet,
-    azurerm_role_assignment.vnet
-  ]
-}
+# ## ARO Public mode (Default)
+# resource "azureopenshift_redhatopenshift_cluster" "cluster" {
+#   count               = var.aro_private ? 0 : 1
+#   name                = var.cluster_name
+#   location            = azurerm_resource_group.main.location
+#   resource_group_name = azurerm_resource_group.main.name
+#   tags                = var.tags
+#   master_profile {
+#     subnet_id = azurerm_subnet.control_plane_subnet.id
+#   }
+#   worker_profile {
+#     subnet_id = azurerm_subnet.machine_subnet.id
+#   }
+#   service_principal {
+#     client_id     = azuread_application.cluster.application_id
+#     client_secret = azuread_application_password.cluster.value
+#   }
+#   depends_on = [
+#     azurerm_subnet.machine_subnet,
+#     azurerm_subnet.control_plane_subnet,
+#     azurerm_role_assignment.vnet
+#   ]
+# }
+
+# ## ARO Private mode
+# resource "azureopenshift_redhatopenshift_cluster" "private" {
+#   count               = var.aro_private ? 1 : 0
+#   name                = var.cluster_name
+#   location            = azurerm_resource_group.main.location
+#   resource_group_name = azurerm_resource_group.main.name
+#   tags                = var.tags
+
+#   master_profile {
+#     subnet_id = azurerm_subnet.control_plane_subnet.id
+#   }
+#   worker_profile {
+#     subnet_id = azurerm_subnet.machine_subnet.id
+#   }
+#   service_principal {
+#     client_id     = azuread_application.cluster.application_id
+#     client_secret = azuread_application_password.cluster.value
+#   }
+
+#   api_server_profile {
+#     visibility = "VisibilityPrivate"
+#   }
+
+#   ingress_profile {
+#     visibility = "VisibilityPrivate"
+#   }
+
+#   depends_on = [
+#     azurerm_subnet.machine_subnet,
+#     azurerm_subnet.control_plane_subnet,
+#     azurerm_role_assignment.vnet
+#   ]
+# }

--- a/variable.tf
+++ b/variable.tf
@@ -5,10 +5,10 @@ variable "cluster_name" {
 }
 
 variable "tags" {
-  type        = map(string)
-  default     = {
+  type = map(string)
+  default = {
     environment = "development"
-    owner = "your@email.address"
+    owner       = "your@email.address"
   }
 }
 
@@ -26,8 +26,14 @@ variable "resource_group_name" {
 
 variable "aro_virtual_network_cidr_block" {
   type        = string
-  default     = "10.0.0.0/22"
+  default     = "10.0.0.0/20"
   description = "cidr range for aro virtual network"
+}
+
+variable "aro_virtual_network_firewall_cidr_block" {
+  type        = string
+  default     = "10.10.0.0/20"
+  description = "cidr range for Azure Firewall virtual network"
 }
 
 variable "aro_control_subnet_cidr_block" {
@@ -40,4 +46,26 @@ variable "aro_machine_subnet_cidr_block" {
   type        = string
   default     = "10.0.2.0/23"
   description = "cidr range for aro machine subnet"
+}
+
+variable "aro_jumphost_subnet_cidr_block" {
+  type        = string
+  default     = "10.0.4.0/23"
+  description = "cidr range for bastion / jumphost"
+}
+
+variable "egress_lockdown" {
+  type        = bool
+  default     = false
+  description = "Enable the Egress Lockdown for Private ARO clusters"
+}
+
+variable "aro_private" {
+  type        = bool
+  default     = false
+  description = <<EOF
+  Deploy an ARO cluster in a private mode. 
+  Default "false"
+  EOF
+
 }


### PR DESCRIPTION
Added the ARO private cluster with the egress lockdown based in https://mobb.ninja/docs/aro/private-cluster and https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress guides.

The variables controls the public / private and the egress lockdown option for the egress:
- **aro_private**: true - Deploys an ARO cluster in private mode and deploys the jumphost to connect
- **egress_lockdown**: true - enables egress lockdown in the private ARO cluster

Updated the makefile to support the egress lockdown + private mode with one command: ```make create_private```

Tested and working with latest ARO cluster version (4.10.20)