### PR TITLE
Minor changes in naming and document private aro cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ create: init
 create-private: init
 	terraform plan -out aro.plan 		\
 		-var "cluster_name=aro-${USER}" \
-		-var "egress_lockdown=true"		\
+		-var "restrict_egress_traffic=true"		\
 		-var "aro_private=true"
 
 	terraform apply aro.plan

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Using the code in the repo will require having the following tools installed:
 
 ### Create the ARO cluster and required infrastructure
 
+#### Public ARO cluster
+
 1. Modify the `variable.tf` var file, or modify the following command to customize your cluster.
 
    ```
@@ -18,6 +20,19 @@ Using the code in the repo will require having the following tools installed:
    terraform plan -var "cluster_name=my-tf-cluster" -out aro.plan
    terraform apply aro.plan
    ```
+
+#### Private ARO cluster
+
+1. Modify the `variable.tf` var file, or modify the following command to customize your cluster.
+
+   ```
+   terraform init
+   terraform plan -var "cluster_name=my-tf-cluster" -var "aro_private=True" -var "restrict_egress_traffic=True"  -out aro.plan
+   terraform apply aro.plan
+   ```
+
+   NOTE: restrict_egress_traffic=True will secure ARO cluster by routing [Egress traffic through an Azure Firewall](https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress).
+
 
 ### Test Connectivity
 

--- a/README.md
+++ b/README.md
@@ -2,30 +2,32 @@
 
 Azure Red Hat OpenShift (ARO) is a fully-managed turnkey application platform.
 
-### Setup
+Supports Public ARO clusters and Private ARO clusters.
+
+## Setup
 
 Using the code in the repo will require having the following tools installed:
 
 - The Terraform CLI
 - The OC CLI
 
-### Create the ARO cluster and required infrastructure
+## Create the ARO cluster and required infrastructure
 
-#### Public ARO cluster
+### Public ARO cluster
 
 1. Modify the `variable.tf` var file, or modify the following command to customize your cluster.
 
-   ```
+   ```bash
    terraform init
    terraform plan -var "cluster_name=my-tf-cluster" -out aro.plan
    terraform apply aro.plan
    ```
 
-#### Private ARO cluster
+### Private ARO cluster
 
 1. Modify the `variable.tf` var file, or modify the following command to customize your cluster.
 
-   ```
+   ```bash
    terraform init
    terraform plan -var "cluster_name=my-tf-cluster" -var "aro_private=True" -var "restrict_egress_traffic=True"  -out aro.plan
    terraform apply aro.plan
@@ -33,35 +35,66 @@ Using the code in the repo will require having the following tools installed:
 
    NOTE: restrict_egress_traffic=True will secure ARO cluster by routing [Egress traffic through an Azure Firewall](https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress).
 
-
-### Test Connectivity
+## Test Connectivity
 
 1. Get the ARO cluster's console URL.
 
-   ```
-   az aro show \
-     --name $AZR_CLUSTER \
-     --resource-group $AZR_RESOURCE_GROUP \
-     -o tsv --query consoleProfile
+   ```bash
+   ARO_URL=$(az aro show -n $AZR_CLUSTER -g $AZR_RESOURCE_GROUP -o json | jq -r '.apiserverProfile.url')
+   echo $ARO_URL
    ```
 
 1. Get the ARO cluster's credentials.
 
+   ```bash
+   ARO_USERNAME=$(az aro list-credentials -n $AZR_CLUSTER -g $AZR_RESOURCE_GROUP -o json | jq -r '.kubeadminUsername')
+   ARO_PASSWORD=$(az aro list-credentials -n $AZR_CLUSTER -g $AZR_RESOURCE_GROUP -o json | jq -r '.kubeadminPassword')
+   echo $ARO_PASSWORD
+   echo $ARO_USERNAME
    ```
-   az aro list-credentials \
-    --name $AZR_CLUSTER \
-    --resource-group $AZR_RESOURCE_GROUP \
-    -o tsv
-   ```
+
+### Public Test Connectivity
 
 1. Log into the cluster using oc login command from the create admin command above. ex.
 
     ```bash
-    oc login https://api.$YOUR_OPENSHIFT_DNS:6443 --username kubeadmin --password xxxxxxxxxx
+    oc login $ARO_URL -u $ARO_USERNAME -p $ARO_PASSWORD
     ```
 
 1. Check that you can access the Console by opening the console url in your browser.
 
+### Private Test Connectivity
+
+1. Save the jump host public IP address
+
+    ```bash
+   JUMP_IP=$(az vm list-ip-addresses -g $AZR_RESOURCE_GROUP -n $AZR_CLUSTER-jumphost -o tsv \
+   --query '[].virtualMachine.network.publicIpAddresses[0].ipAddress')
+   echo $JUMP_IP
+   ```
+
+1. update /etc/hosts to point the openshift domains to localhost. Use the DNS of your openshift cluster as described in the previous step in place of $YOUR_OPENSHIFT_DNS below
+
+   ```bash
+   127.0.0.1 api.$YOUR_OPENSHIFT_DNS
+   127.0.0.1 console-openshift-console.apps.$YOUR_OPENSHIFT_DNS
+   127.0.0.1 oauth-openshift.apps.$YOUR_OPENSHIFT_DNS
+   ```
+
+1. SSH to that instance, tunneling traffic for the appropriate hostnames. Be sure to use your new/existing private key, the OpenShift DNS for $YOUR_OPENSHIFT_DNS and your Jumphost IP
+
+   ```bash
+   sudo ssh -L 6443:api.$YOUR_OPENSHIFT_DNS:6443 \
+   -L 443:console-openshift-console.apps.$YOUR_OPENSHIFT_DNS:443 \
+   -L 80:console-openshift-console.apps.$YOUR_OPENSHIFT_DNS:80 \
+   aro@$JUMP_IP
+   ```
+
+1. Log in using oc login
+
+   ```bash
+   oc login $ARO_URL -u $ARO_USERNAME -p $ARO_PASSWORD
+   ```
 
 ## Cleanup
 

--- a/egress.tf
+++ b/egress.tf
@@ -1,8 +1,8 @@
-# Egress Lockdown in a Private ARO Cluster
-# For enable egress_lockdown define egress_lockdown = "true" in the tfvars / vars
+# Restrict Egress Traffic in a Private ARO Cluster
+# For enable restrict_egress_traffic define restrict_egress_traffic = "true" in the tfvars / vars
 
 resource "azurerm_virtual_network" "firewall_vnet" {
-  count               = var.egress_lockdown ? 1 : 0
+  count               = var.restrict_egress_traffic ? 1 : 0
   name                = "${local.name_prefix}-fw-vnet"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
@@ -11,7 +11,7 @@ resource "azurerm_virtual_network" "firewall_vnet" {
 }
 
 resource "azurerm_subnet" "firewall_subnet" {
-  count                = var.egress_lockdown ? 1 : 0
+  count                = var.restrict_egress_traffic ? 1 : 0
   name                 = "AzureFirewallSubnet"
   resource_group_name  = azurerm_resource_group.main.name
   virtual_network_name = azurerm_virtual_network.firewall_vnet.0.name
@@ -20,7 +20,7 @@ resource "azurerm_subnet" "firewall_subnet" {
 }
 
 resource "azurerm_public_ip" "firewall_ip" {
-  count               = var.egress_lockdown ? 1 : 0
+  count               = var.restrict_egress_traffic ? 1 : 0
   name                = "${local.name_prefix}-fw-ip"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
@@ -31,7 +31,7 @@ resource "azurerm_public_ip" "firewall_ip" {
 }
 
 resource "azurerm_firewall" "firewall" {
-  count               = var.egress_lockdown ? 1 : 0
+  count               = var.restrict_egress_traffic ? 1 : 0
   name                = "${local.name_prefix}-firewall"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
@@ -47,7 +47,7 @@ resource "azurerm_firewall" "firewall" {
 }
 
 resource "azurerm_route_table" "firewall_rt" {
-  count               = var.egress_lockdown ? 1 : 0
+  count               = var.restrict_egress_traffic ? 1 : 0
   name                = "${local.name_prefix}-fw-rt"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
@@ -73,7 +73,7 @@ resource "azurerm_route_table" "firewall_rt" {
 
 # TODO: Restrict the FW Network Rules
 resource "azurerm_firewall_network_rule_collection" "firewall_network_rules" {
-  count               = var.egress_lockdown ? 1 : 0
+  count               = var.restrict_egress_traffic ? 1 : 0
   name                = "allow-https"
   azure_firewall_name = azurerm_firewall.firewall.0.name
   resource_group_name = azurerm_resource_group.main.name
@@ -99,7 +99,7 @@ resource "azurerm_firewall_network_rule_collection" "firewall_network_rules" {
 
 
 resource "azurerm_firewall_application_rule_collection" "firewall_app_rules_google" {
-  count               = var.egress_lockdown ? 1 : 0
+  count               = var.restrict_egress_traffic ? 1 : 0
   name                = "ARO"
   azure_firewall_name = azurerm_firewall.firewall.0.name
   resource_group_name = azurerm_resource_group.main.name
@@ -129,7 +129,7 @@ resource "azurerm_firewall_application_rule_collection" "firewall_app_rules_goog
 }
 
 resource "azurerm_firewall_application_rule_collection" "firewall_app_rules_docker" {
-  count               = var.egress_lockdown ? 1 : 0
+  count               = var.restrict_egress_traffic ? 1 : 0
   name                = "Docker"
   azure_firewall_name = azurerm_firewall.firewall.0.name
   resource_group_name = azurerm_resource_group.main.name
@@ -159,13 +159,13 @@ resource "azurerm_firewall_application_rule_collection" "firewall_app_rules_dock
 }
 
 resource "azurerm_subnet_route_table_association" "firewall_rt_aro_cp_subnet_association" {
-  count          = var.egress_lockdown ? 1 : 0
+  count          = var.restrict_egress_traffic ? 1 : 0
   subnet_id      = azurerm_subnet.control_plane_subnet.id
   route_table_id = azurerm_route_table.firewall_rt.0.id
 }
 
 resource "azurerm_subnet_route_table_association" "firewall_rt_aro_machine_subnet_association" {
-  count          = var.egress_lockdown ? 1 : 0
+  count          = var.restrict_egress_traffic ? 1 : 0
   subnet_id      = azurerm_subnet.machine_subnet.id
   route_table_id = azurerm_route_table.firewall_rt.0.id
 }

--- a/jumphost.tf
+++ b/jumphost.tf
@@ -106,7 +106,3 @@ resource "azurerm_linux_virtual_machine" "jumphost-vm" {
 
   tags = var.tags
 }
-
-output "public_ip" {
-  value = azurerm_public_ip.jumphost-pip.0.ip_address
-}

--- a/jumphost.tf
+++ b/jumphost.tf
@@ -90,9 +90,10 @@ resource "azurerm_linux_virtual_machine" "jumphost-vm" {
 
   provisioner "remote-exec" {
     connection {
-      type = "ssh"
-      host = azurerm_public_ip.jumphost-pip.0.ip_address
-      user = "aro"
+      type        = "ssh"
+      host        = azurerm_public_ip.jumphost-pip.0.ip_address
+      user        = "aro"
+      private_key = file("~/.ssh/id_rsa")
     }
     inline = [
       "sudo dnf install telnet wget bash-completion -y",

--- a/variable.tf
+++ b/variable.tf
@@ -57,7 +57,10 @@ variable "aro_jumphost_subnet_cidr_block" {
 variable "egress_lockdown" {
   type        = bool
   default     = false
-  description = "Enable the Egress Lockdown for Private ARO clusters"
+  description = <<EOF
+  Enable the Egress Lockdown for Private ARO clusters.
+  Default "false"
+  EOF
 }
 
 variable "aro_private" {

--- a/variable.tf
+++ b/variable.tf
@@ -54,11 +54,11 @@ variable "aro_jumphost_subnet_cidr_block" {
   description = "cidr range for bastion / jumphost"
 }
 
-variable "egress_lockdown" {
+variable "restrict_egress_traffic" {
   type        = bool
   default     = false
   description = <<EOF
-  Enable the Egress Lockdown for Private ARO clusters.
+  Enable the Restrict Egress Traffic for Private ARO clusters.
   Default "false"
   EOF
 }


### PR DESCRIPTION
- Changes in naming (usage of Restrict Egress Traffic) as is described in https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress
- Document the ARO Private Cluster and add the Test Connectivity
- Fix the private ssh key in remote-exec connection block (now is defined)

Thanks @datianshi for the tips!
 