### PR TITLE
Terraform expect the value true not True. typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Using the code in the repo will require having the following tools installed:
 
    ```bash
    terraform init
-   terraform plan -var "cluster_name=my-tf-cluster" -var "aro_private=True" -var "restrict_egress_traffic=True"  -out aro.plan
+   terraform plan -var "cluster_name=my-tf-cluster" -var "aro_private=true" -var "restrict_egress_traffic=true"  -out aro.plan
    terraform apply aro.plan
    ```
 
-   NOTE: restrict_egress_traffic=True will secure ARO cluster by routing [Egress traffic through an Azure Firewall](https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress).
+   NOTE: restrict_egress_traffic=true will secure ARO cluster by routing [Egress traffic through an Azure Firewall](https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress).
 
 ## Test Connectivity
 


### PR DESCRIPTION
terraform is failing when you use the value "True" instead of "true". Please see the error below.

data.azurerm_subscription.current: Read complete after 0s [id=/subscriptions/e7f88b1a-04fc-4d00-ace9-eec077a5d6af]
╷
│ Warning: Argument is deprecated
│
│   with azurerm_subnet.control_plane_subnet,
│   on main.tf line 27, in resource "azurerm_subnet" "control_plane_subnet":
│   27:   enforce_private_link_service_network_policies  = true
│
│ `enforce_private_link_service_network_policies` will be removed in favour of the property
│ `private_link_service_network_policies_enabled` in version 4.0 of the AzureRM Provider
│
│ (and 3 more similar warnings elsewhere)
╵
╷
│ Error: Invalid value for input variable
│
│   on variable.tf line 57:
│   57: variable "restrict_egress_traffic" {
│
│ Unsuitable value for var.restrict_egress_traffic set using -var="restrict_egress_traffic=...": a bool is required; to convert from
│ string, use lowercase "true".
╵
╷
│ Error: Invalid value for input variable
│
│   on variable.tf line 66:
│   66: variable "aro_private" {
│
│ Unsuitable value for var.aro_private set using -var="aro_private=...": a bool is required; to convert from string, use lowercase
│ "true".
╵