### PR TITLE
fix pull-secret and added more network rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,26 @@ init:
 create: init
 	terraform plan -out aro.plan 		\
 		-var "cluster_name=aro-${USER}" \
-
+		-var "pull_secret_path=~/Downloads/pull-secret.json"
 	terraform apply aro.plan
 
 create-private: init
 	terraform plan -out aro.plan 		\
 		-var "cluster_name=aro-${USER}" \
 		-var "restrict_egress_traffic=true"		\
-		-var "aro_private=true"
+		-var "aro_private=true" \
+		-var "pull_secret_path=~/Downloads/pull-secret.json"
 
 	terraform apply aro.plan
 
+create-private-noegress: init
+	terraform plan -out aro.plan 		\
+		-var "cluster_name=aro-${USER}" \
+		-var "restrict_egress_traffic=false"		\
+		-var "aro_private=true" \
+		-var "pull_secret_path=~/Downloads/pull-secret.json"
+
+	terraform apply aro.plan
 
 destroy:
 	terraform destroy

--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,10 @@ resource "azureopenshift_redhatopenshift_cluster" "private" {
     visibility = "Private"
   }
 
+  cluster_profile {
+    pull_secret = file(var.pull_secret_path)
+  }
+
   depends_on = [
     azurerm_subnet.machine_subnet,
     azurerm_subnet.control_plane_subnet,

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,17 +1,17 @@
 terraform {
   required_providers {
     azuread = {
-      source = "hashicorp/azuread"
+      source  = "hashicorp/azuread"
       version = "~>2.24"
     }
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "~>3.0"
     }
 
     azureopenshift = {
-      source    = "rh-mobb/azureopenshift"
-      version   = "~>0.0.5"
+      source  = "rh-mobb/azureopenshift"
+      version = "~>0.0.14"
     }
   }
 }
@@ -26,4 +26,4 @@ provider "azurerm" {
 }
 
 
-provider azureopenshift {}
+provider "azureopenshift" {}

--- a/variable.tf
+++ b/variable.tf
@@ -30,12 +30,6 @@ variable "aro_virtual_network_cidr_block" {
   description = "cidr range for aro virtual network"
 }
 
-variable "aro_virtual_network_firewall_cidr_block" {
-  type        = string
-  default     = "10.10.0.0/20"
-  description = "cidr range for Azure Firewall virtual network"
-}
-
 variable "aro_control_subnet_cidr_block" {
   type        = string
   default     = "10.0.0.0/23"
@@ -52,6 +46,12 @@ variable "aro_jumphost_subnet_cidr_block" {
   type        = string
   default     = "10.0.4.0/23"
   description = "cidr range for bastion / jumphost"
+}
+
+variable "aro_firewall_subnet_cidr_block" {
+  type        = string
+  default     = "10.0.6.0/23"
+  description = "cidr range for Azure Firewall virtual network"
 }
 
 variable "restrict_egress_traffic" {
@@ -71,4 +71,13 @@ variable "aro_private" {
   Default "false"
   EOF
 
+}
+
+variable "pull_secret_path" {
+  type        = string
+  default     = false
+  description = <<EOF
+  Pull Secret for the ARO cluster 
+  Default "false"
+  EOF
 }


### PR DESCRIPTION
Includes:
- Pull request in Public/Private creation
- Bump of terraform provider aro version to last version available (0.0.14)

Fixes:
- Azure vnet firewall creation issues (now Az FW lives within the aro subnet following https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress#create-an-azure-firewall
- Added firewall rules in order to remove the allow-all fw rules
- Adapted the Makefile to accept pull-secret

Tested with Create a private cluster without a public IP address (Public Preview) also: https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x#create-a-private-cluster-without-a-public-ip-address-preview