### PR TITLE
Add ACR for Private ARO Clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .terraform*
 *.plan
 terraform.tfvars
+sshuttle.pid

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,11 @@ create: init
 .PHONY: create-private
 create-private: init
 	terraform plan -out aro.plan 		                       \
-		-var "cluster_name=aro-$(whoami)"                      \
+		-var "cluster_name=aro-$(whoami)"                    \
 		-var "restrict_egress_traffic=true"		               \
 		-var "api_server_profile=Private"                    \
-		-var "ingress_profile=Private"
+		-var "ingress_profile=Private"                       \
+		-var "acr_private=false"
 
 	terraform apply aro.plan
 
@@ -50,3 +51,7 @@ destroy.force:
 .PHONY: delete
 delete: destroy
 
+.PHONY: clean
+clean:
+	rm -rf terraform.tfstate*
+	rm -rf .terraform*

--- a/Makefile
+++ b/Makefile
@@ -15,25 +15,25 @@ init:
 .PHONY: create
 create: init
 	terraform plan -out aro.plan 		                       \
-		-var "cluster_name=aro-$(whoami)"
+		-var "cluster_name=aro-$(shell whoami)"
 
 	terraform apply aro.plan
 
 .PHONY: create-private
 create-private: init
 	terraform plan -out aro.plan 		                       \
-		-var "cluster_name=aro-$(whoami)"                    \
+		-var "cluster_name=aro-$(shell whoami)"              \
 		-var "restrict_egress_traffic=true"		               \
 		-var "api_server_profile=Private"                    \
 		-var "ingress_profile=Private"                       \
-		-var "acr_private=false"
+		-var "acr_private=true"
 
 	terraform apply aro.plan
 
 .PHONY: create-private-noegress
 create-private-noegress: init
 	terraform plan -out aro.plan 		                       \
-		-var "cluster_name=aro-$(whoami)"                      \
+		-var "cluster_name=aro-$(shell whoami)"              \
 		-var "restrict_egress_traffic=false"		             \
 		-var "api_server_profile=Private"                    \
 		-var "ingress_profile=Private"

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ create-private: init
 		-var "restrict_egress_traffic=true"		               \
 		-var "api_server_profile=Private"                    \
 		-var "ingress_profile=Private"                       \
-		-var "acr_private=true"
+		-var "acr_private=false"
 
 	terraform apply aro.plan
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Using the code in the repo will require having the following tools installed:
    oc login $ARO_URL -u $ARO_USERNAME -p $ARO_PASSWORD
    ```
 
+NOTE: Another option to connect to a Private ARO cluster jumphost is the usage of [sshuttle](https://sshuttle.readthedocs.io/en/stable/index.html). If we suppose that we deployed ARO vnet with the `10.0.0.0/20` CIDR we can connect to the cluster using (both API and Console):
+
+```bash
+sshuttle --dns -NHr aro@$JUMP_IP 10.0.0.0/20 --daemon
+```
+
+and opening a browser the `api.$YOUR_OPENSHIFT_DNS` and `console-openshift-console.apps.$YOUR_OPENSHIFT_DNS` will be reachable.
+
 ## Cleanup
 
 1. Delete Cluster and Resources

--- a/acr.tf
+++ b/acr.tf
@@ -26,9 +26,17 @@ resource "azurerm_private_dns_zone_virtual_network_link" "dns_link" {
   registration_enabled  = false
 }
 
+resource "random_string" "acr" {
+  length      = 4
+  min_numeric = 4
+  keepers = {
+    name = "acraro"
+  }
+}
+
 resource "azurerm_container_registry" "acr" {
   count                         = var.acr_private ? 1 : 0
-  name                          = "acraro"
+  name                          = "acraro${random_string.acr.result}"
   location                      = azurerm_resource_group.main.location
   resource_group_name           = azurerm_resource_group.main.name
   sku                           = "Premium"

--- a/acr.tf
+++ b/acr.tf
@@ -1,0 +1,60 @@
+# Azure Container Registry (ACR) in Private ARO Clusters
+# https://learn.microsoft.com/en-us/azure/container-registry/container-registry-private-link
+
+resource "azurerm_subnet" "private_endpoint_subnet" {
+  count                                     = var.acr_private ? 1 : 0
+  name                                      = "PrivateEndpoint-subnet"
+  resource_group_name                       = azurerm_resource_group.main.name
+  virtual_network_name                      = azurerm_virtual_network.main.name
+  address_prefixes                          = [var.aro_private_endpoint_cidr_block]
+  private_endpoint_network_policies_enabled = false # To be reviewed
+  #private_link_service_network_policies_enabled = false # To be reviewed
+}
+
+resource "azurerm_private_dns_zone" "dns" {
+  count               = var.acr_private ? 1 : 0
+  name                = "privatelink.azurecr.io"
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "dns_link" {
+  count                 = var.acr_private ? 1 : 0
+  name                  = "acr-dns-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.dns.0.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+  registration_enabled  = false
+}
+
+resource "azurerm_container_registry" "acr" {
+  count                         = var.acr_private ? 1 : 0
+  name                          = "acraro"
+  location                      = azurerm_resource_group.main.location
+  resource_group_name           = azurerm_resource_group.main.name
+  sku                           = "Premium"
+  admin_enabled                 = true
+  public_network_access_enabled = false
+}
+
+resource "azurerm_private_endpoint" "acr" {
+  count               = var.acr_private ? 1 : 0
+  name                = "acr-pe"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  subnet_id           = azurerm_subnet.private_endpoint_subnet.0.id
+
+  private_dns_zone_group {
+    name = "acr-zonegroup"
+    private_dns_zone_ids = [
+      azurerm_private_dns_zone.dns.0.id
+    ]
+  }
+
+  private_service_connection {
+    name                           = "acr-connection"
+    private_connection_resource_id = azurerm_container_registry.acr.0.id
+    is_manual_connection           = false
+    subresource_names              = ["registry"]
+  }
+}
+

--- a/acr.tf
+++ b/acr.tf
@@ -7,8 +7,8 @@ resource "azurerm_subnet" "private_endpoint_subnet" {
   resource_group_name                       = azurerm_resource_group.main.name
   virtual_network_name                      = azurerm_virtual_network.main.name
   address_prefixes                          = [var.aro_private_endpoint_cidr_block]
-  private_endpoint_network_policies_enabled = false # To be reviewed
-  #private_link_service_network_policies_enabled = false # To be reviewed
+  private_endpoint_network_policies_enabled = false
+  #private_link_service_network_policies_enabled = false # To verify
 }
 
 resource "azurerm_private_dns_zone" "dns" {

--- a/egress.tf
+++ b/egress.tf
@@ -3,6 +3,8 @@
 
 # The Azure FW will be into the ARO subnet following the architecture
 # defined in the official docs https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress#create-an-azure-firewall
+
+# TODO: Convert from Non Hub-Spoke to Hub-Spoke model (split vNETs)
 resource "azurerm_subnet" "firewall_subnet" {
   count                = var.restrict_egress_traffic ? 1 : 0
   name                 = "AzureFirewallSubnet"

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "aro_firewall_subnet_cidr_block" {
   description = "cidr range for Azure Firewall virtual network"
 }
 
+variable "aro_private_endpoint_cidr_block" {
+  type        = string
+  default     = "10.0.8.0/23"
+  description = "cidr range for Azure Firewall virtual network"
+}
+
 variable "restrict_egress_traffic" {
   type        = bool
   default     = false
@@ -97,4 +103,13 @@ variable "aro_version" {
   Default "4.11.26"
   EOF
   default     = "4.11.26"
+}
+
+variable "acr_private" {
+  type        = bool
+  default     = false
+  description = <<EOF
+  Deploy ACR for Private ARO clusters.
+  Default "false"
+  EOF
 }


### PR DESCRIPTION
Add Azure Container Registry support for Private ARO Clusters.
- Tested and works for private ARO clusters
![acr1](https://github.com/rh-mobb/terraform-aro/assets/5543225/dde8d380-fc85-4ea1-a1c3-7151ad61932f)
- Deployed an httpd example app from ACR private and worked like a charm.
- Mobb Ninja blog post will be published alongsided explaining the manual process and how to use this to automate it
- added flag into the makefile to control the deployment (false is the default)  