### PR TITLE
Allow rhui-*.microsoft.com through firewall

### DIFF
--- a/egress.tf
+++ b/egress.tf
@@ -112,7 +112,8 @@ resource "azurerm_firewall_application_rule_collection" "firewall_app_rules_aro"
       "mirror.openshift.com",
       "registry.access.redhat.com",
       "*.redhat.com",
-      "*.openshift.com"
+      "*.openshift.com",
+      "rhui-*.microsoft.com"
     ]
     protocol {
       port = "443"


### PR DESCRIPTION
This change allows the jump host to reach it's configured rpm repos when installing packages.