### PR TITLE
Feature/no public ip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ init:
 .PHONY: create
 create: init
 	terraform plan -out aro.plan 		                       \
+		-var "subscription_id=$(TF_VAR_subscription_id)"     \
 		-var "cluster_name=aro-$(shell whoami)"
 
 	terraform apply aro.plan

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ create-private: init
 		-var "restrict_egress_traffic=true"		               \
 		-var "api_server_profile=Private"                    \
 		-var "ingress_profile=Private"                       \
+		-var "outbound_type=UserDefinedRouting"              \
+		-var "subscription_id=$(TF_VAR_subscription_id)"     \
 		-var "acr_private=false"
 
 	terraform apply aro.plan

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Using the code in the repo will require having the following tools installed:
 
 1. Modify the `terraform.tfvars` var file, you can use the `variables.tf` to see the full list of variables that can be set.
 
+   >NOTE: You can define the subscription_id needed for the Auth using ```export TF_VAR_subscription_id="xxx"``` as well.
+
 1. Deploy your cluster
 
    ```bash
@@ -39,7 +41,9 @@ Using the code in the repo will require having the following tools installed:
    make create-private
    ```
 
-   NOTE: restrict_egress_traffic=true will secure ARO cluster by routing [Egress traffic through an Azure Firewall](https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress).
+   >NOTE: restrict_egress_traffic=true will secure ARO cluster by routing [Egress traffic through an Azure Firewall](https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress).
+
+   >NOTE2: Private Clusters can be created [without Public IP using the UserDefineRouting](https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x#create-a-private-cluster-without-a-public-ip-address) flag in the outboundtype=UserDefineRouting variable. By default LoadBalancer is used for the egress.
 
 ## Test Connectivity
 
@@ -122,5 +126,5 @@ and opening a browser the `api.$YOUR_OPENSHIFT_DNS` and `console-openshift-conso
 1. Delete Cluster and Resources
 
     ```bash
-    terraform destroy -auto-approve
+    make destroy-force
     ```

--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,10 @@ resource "azureopenshift_redhatopenshift_cluster" "cluster" {
     version     = var.aro_version
   }
 
+  network_profile {
+    outbound_type = "UserDefinedRouting"
+  }
+
   depends_on = [
     azurerm_role_assignment.vnet,
     azurerm_firewall_network_rule_collection.firewall_network_rules

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "azureopenshift_redhatopenshift_cluster" "cluster" {
   }
 
   network_profile {
-    outbound_type = "UserDefinedRouting"
+    outbound_type = var.outbound_type
   }
 
   depends_on = [

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,16 +2,16 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~>2.24"
+      version = "~>2.43"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.0"
+      version = "~>3.75.0"
     }
 
     azureopenshift = {
       source  = "rh-mobb/azureopenshift"
-      version = "~>0.0.16"
+      version = "0.2.0-pre"
     }
   }
 }
@@ -25,5 +25,6 @@ provider "azurerm" {
 
 }
 
-
-provider "azureopenshift" {}
+provider "azureopenshift" {
+  subscription_id = var.subscription_id
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,2 +1,3 @@
 pull_secret_path = "~/Downloads/pull-secret.txt"
 location = "eastus"
+subscription_id = "TO_BE_FILLED" ## also "export TF_VAR_subscription_id=xxx" can be used

--- a/variables.tf
+++ b/variables.tf
@@ -100,9 +100,9 @@ variable "aro_version" {
   type        = string
   description = <<EOF
   ARO version
-  Default "4.11.26"
+  Default "4.12.25"
   EOF
-  default     = "4.11.26"
+  default     = "4.12.25"
 }
 
 variable "acr_private" {
@@ -112,4 +112,19 @@ variable "acr_private" {
   Deploy ACR for Private ARO clusters.
   Default "false"
   EOF
+}
+
+variable "outbound_type" {
+  type        = string
+  description = <<EOF
+  Outbound Type - Loadbalancer or UserDefinedRouting
+  Default "Loadbalancer"
+  EOF
+  default     = "Loadbalancer"
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "Azure Subscription ID (needed with the new Auth method)"
+  default     = "Use_Your_Subs_ID"
 }


### PR DESCRIPTION
Overview:
Fix the issue https://github.com/rh-mobb/terraform-aro/issues/23 and to enable the ability to create private aro clusters without Public IP

- Tested with 4.12.25.
- Updated docs
- Bumped tf provider versions to the latest (included 0.2.0-pre of the tf-provider)
- Added subscription_id as per requested in the new auth of the azuread/rm
- Deleted unused tfvars folder