### PR TITLE
feat: switch to new terraform provider resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   name_prefix = var.cluster_name
+  pull_secret = var.pull_secret_path != null && var.pull_secret_path != "" ? file(var.pull_secret_path) : null
 }
 
 resource "azurerm_resource_group" "main" {
@@ -39,22 +40,85 @@ resource "azurerm_subnet" "machine_subnet" {
 
 ## ARO Cluster
 
-resource "azureopenshift_redhatopenshift_cluster" "cluster" {
-  name                   = var.cluster_name
-  location               = azurerm_resource_group.main.location
-  resource_group_name    = azurerm_resource_group.main.name
-  cluster_resource_group = "${local.name_prefix}-cluster-rg"
-  tags                   = var.tags
+# Old unsupported provider: https://github.com/rh-mobb/terraform-provider-azureopenshift
 
-  master_profile {
+# resource "azureopenshift_redhatopenshift_cluster" "cluster" {
+#   name                   = var.cluster_name
+#   location               = azurerm_resource_group.main.location
+#   resource_group_name    = azurerm_resource_group.main.name
+#   cluster_resource_group = "${local.name_prefix}-cluster-rg"
+#   tags                   = var.tags
+
+#   master_profile {
+#     subnet_id = azurerm_subnet.control_plane_subnet.id
+#   }
+#   worker_profile {
+#     subnet_id = azurerm_subnet.machine_subnet.id
+#   }
+#   service_principal {
+#     client_id     = azuread_application.cluster.application_id
+#     client_secret = azuread_application_password.cluster.value
+#   }
+
+#   api_server_profile {
+#     visibility = var.api_server_profile
+#   }
+
+#   ingress_profile {
+#     visibility = var.ingress_profile
+#   }
+
+#   cluster_profile {
+#     pull_secret = file(var.pull_secret_path)
+#     version     = var.aro_version
+#   }
+
+#   network_profile {
+#     outbound_type = var.outbound_type
+#   }
+
+#   depends_on = [
+#     azurerm_role_assignment.vnet,
+#     azurerm_firewall_network_rule_collection.firewall_network_rules
+#   ]
+# }
+
+## ARO Cluster
+
+# See docs at https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redhat_openshift_cluster
+
+resource "azurerm_redhat_openshift_cluster" "cluster" {
+  name                = var.cluster_name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
+
+  # NOTE: this input is missing to provide parity with the old provider at 
+  #       https://github.com/rh-mobb/terraform-provider-azureopenshift
+  # cluster_resource_group = "${var.cluster_name}-cluster-rg"
+
+  cluster_profile {
+    domain      = var.domain
+    pull_secret = local.pull_secret
+    version     = var.aro_version
+  }
+
+  main_profile {
+    vm_size   = var.main_vm_size
     subnet_id = azurerm_subnet.control_plane_subnet.id
   }
+
   worker_profile {
-    subnet_id = azurerm_subnet.machine_subnet.id
+    subnet_id    = azurerm_subnet.machine_subnet.id
+    disk_size_gb = var.worker_disk_size_gb
+    node_count   = var.worker_node_count
+    vm_size      = var.worker_vm_size
   }
-  service_principal {
-    client_id     = azuread_application.cluster.application_id
-    client_secret = azuread_application_password.cluster.value
+
+  network_profile {
+    outbound_type = var.outbound_type
+    pod_cidr      = var.aro_pod_cidr_block
+    service_cidr  = var.aro_service_cidr_block
   }
 
   api_server_profile {
@@ -65,17 +129,17 @@ resource "azureopenshift_redhatopenshift_cluster" "cluster" {
     visibility = var.ingress_profile
   }
 
-  cluster_profile {
-    pull_secret = file(var.pull_secret_path)
-    version     = var.aro_version
-  }
-
-  network_profile {
-    outbound_type = var.outbound_type
+  service_principal {
+    client_id     = azuread_application.cluster.application_id
+    client_secret = azuread_application_password.cluster.value
   }
 
   depends_on = [
     azurerm_role_assignment.vnet,
     azurerm_firewall_network_rule_collection.firewall_network_rules
   ]
+}
+
+output "console_url" {
+  value = azurerm_redhat_openshift_cluster.cluster.console_url
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,14 +4,10 @@ terraform {
       source  = "hashicorp/azuread"
       version = "~>2.43"
     }
+
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.75.0"
-    }
-
-    azureopenshift = {
-      source  = "rh-mobb/azureopenshift"
-      version = "0.2.0-pre"
+      version = "~>3.92.0"
     }
   }
 }
@@ -23,8 +19,4 @@ provider "azurerm" {
     }
   }
 
-}
-
-provider "azureopenshift" {
-  subscription_id = var.subscription_id
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,3 +1,4 @@
 pull_secret_path = "~/Downloads/pull-secret.txt"
 location = "eastus"
 subscription_id = "TO_BE_FILLED" ## also "export TF_VAR_subscription_id=xxx" can be used
+domain = "example.com"  ## required by the backend terraform provider

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,9 @@
+variable "subscription_id" {}
+
+module "test" {
+  source = "../"
+
+  subscription_id = var.subscription_id
+  cluster_name    = "test-cluster"
+  domain          = "example.com"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,18 @@ variable "aro_private_endpoint_cidr_block" {
   description = "cidr range for Azure Firewall virtual network"
 }
 
+variable "aro_pod_cidr_block" {
+  type        = string
+  default     = "10.128.0.0/14"
+  description = "cidr range for pods within the cluster network"
+}
+
+variable "aro_service_cidr_block" {
+  type        = string
+  default     = "172.30.0.0/16"
+  description = "cidr range for services within the cluster network"
+}
+
 variable "restrict_egress_traffic" {
   type        = bool
   default     = false
@@ -76,6 +88,11 @@ variable "api_server_profile" {
   Default "Public"
   EOF
   default     = "Public"
+
+  validation {
+    condition     = contains(["Public", "Private"], var.api_server_profile)
+    error_message = "Invalid 'api_server_profile'. Only 'Public' or 'Private' are allowed."
+  }
 }
 
 variable "ingress_profile" {
@@ -85,14 +102,19 @@ variable "ingress_profile" {
   Default "Public"
   EOF
   default     = "Public"
+
+  validation {
+    condition     = contains(["Public", "Private"], var.ingress_profile)
+    error_message = "Invalid 'ingress_profile'. Only 'Public' or 'Private' are allowed."
+  }
 }
 
 variable "pull_secret_path" {
   type        = string
-  default     = false
+  default     = null
   description = <<EOF
   Pull Secret for the ARO cluster
-  Default "false"
+  Default null
   EOF
 }
 
@@ -121,9 +143,70 @@ variable "outbound_type" {
   Default "Loadbalancer"
   EOF
   default     = "Loadbalancer"
+
+  validation {
+    condition     = contains(["Loadbalancer", "UserDefinedRouting"], var.outbound_type)
+    error_message = "Invalid 'outbound_type'. Only 'Loadbalancer' or 'UserDefinedRouting' are allowed."
+  }
 }
 
 variable "subscription_id" {
   type        = string
   description = "Azure Subscription ID (needed with the new Auth method)"
+}
+
+# NOTE: this is a required input as per the new ARO provider
+#       https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redhat_openshift_cluster
+variable "domain" {
+  type        = string
+  description = "Domain for the cluster."
+
+  validation {
+    condition     = var.domain != "" && var.domain != null
+    error_message = "Invalid 'domain'. Must be not be empty."
+  }
+}
+
+variable "main_vm_size" {
+  type        = string
+  description = "VM size for the main, control plane VMs."
+  default     = "Standard_D8s_v3"
+
+  validation {
+    condition     = var.main_vm_size != "" && var.main_vm_size != null
+    error_message = "Invalid 'main_vm_size'. Must be not be empty."
+  }
+}
+
+variable "worker_vm_size" {
+  type        = string
+  description = "VM size for the worker VMs."
+  default     = "Standard_D4s_v3"
+
+  validation {
+    condition     = var.worker_vm_size != "" && var.worker_vm_size != null
+    error_message = "Invalid 'worker_vm_size'. Must be not be empty."
+  }
+}
+
+variable "worker_disk_size_gb" {
+  type        = number
+  default     = 128
+  description = "Disk size for the worker nodes."
+
+  validation {
+    condition     = var.worker_disk_size_gb >= 128
+    error_message = "Invalid 'worker_disk_size_gb'. Minimum of 128GB."
+  }
+}
+
+variable "worker_node_count" {
+  type        = number
+  default     = 3
+  description = "Number of worker nodes."
+
+  validation {
+    condition     = var.worker_node_count >= 3
+    error_message = "Invalid 'worker_node_count'. Minimum of 3."
+  }
 }


### PR DESCRIPTION
This commit does the following:

- Switches to new TF provider for ARO
- Adds inputs for the new TF provider
- Makes the pull_secret optional and correctly pulls in the file
- Comments out the old provider in case for reference purposes
- Adds input validation for things like outbound_type and ingress/api profile
- Adds sample test