### PR TITLE
feat: use minimal permissions

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -15,6 +15,9 @@ resource "random_string" "domain" {
 }
 
 resource "azurerm_redhat_openshift_cluster" "cluster" {
+  # NOTE: use the installer service principal that we created to create our cluster
+  provider = azurerm.installer
+
   name                = var.cluster_name
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
@@ -57,8 +60,8 @@ resource "azurerm_redhat_openshift_cluster" "cluster" {
   }
 
   service_principal {
-    client_id     = azuread_application.cluster.client_id
-    client_secret = azuread_application_password.cluster.value
+    client_id     = module.aro_permissions.cluster_service_principal_client_id
+    client_secret = module.aro_permissions.cluster_service_principal_client_secret
   }
 
   depends_on = [

--- a/cluster.tf
+++ b/cluster.tf
@@ -65,8 +65,8 @@ resource "azurerm_redhat_openshift_cluster" "cluster" {
   }
 
   depends_on = [
-    azurerm_role_assignment.vnet,
-    azurerm_firewall_network_rule_collection.firewall_network_rules
+    module.aro_permissions,
+    azurerm_firewall_network_rule_collection.firewall_network_rules,
   ]
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -1,14 +1,12 @@
 data "azurerm_client_config" "current" {}
 
-data "azuread_client_config" "current" {}
-
 locals {
   installer_service_principal_name = "${var.cluster_name}-installer"
   cluster_service_principal_name   = "${var.cluster_name}-cluster"
 }
 
 module "aro_permissions" {
-  source = "git::https://github.com/rh-mobb/terraform-aro-permissions.git?ref=v0.0.3"
+  source = "git::https://github.com/rh-mobb/terraform-aro-permissions.git?ref=main"
 
   # NOTE: terraform installation == 'api' installation_type (as opposed to 'cli')
   installation_type = "api"
@@ -16,11 +14,15 @@ module "aro_permissions" {
   # do not output the credentials to a file
   output_as_file = true
 
+  # use custom roles with minimal permissions
+  minimal_network_role = "${var.cluster_name}-network"
+  minimal_aro_role     = "${var.cluster_name}-aro"
+
   # cluster parameters
   cluster_name           = var.cluster_name
   vnet                   = azurerm_virtual_network.main.name
   vnet_resource_group    = azurerm_resource_group.main.name
-  network_security_group = azurerm_network_security_group.aro.id
+  network_security_group = azurerm_network_security_group.aro.name
 
   aro_resource_group = {
     name   = azurerm_resource_group.main.name
@@ -37,10 +39,6 @@ module "aro_permissions" {
     name   = local.installer_service_principal_name
     create = true
   }
-
-  # use custom roles with minimal permissions
-  minimal_network_role = "${var.cluster_name}-network"
-  minimal_aro_role     = "${var.cluster_name}-aro"
 
   # set custom permissions
   nat_gateways = []

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,10 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~>2.53"
-    }
-
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~>4.9.0"

--- a/terraform.tf
+++ b/terraform.tf
@@ -13,7 +13,11 @@ terraform {
 }
 
 provider "azurerm" {
-  subscription_id = var.subscription_id
+  alias           = "installer"
+  client_id       = terraform_data.installer_credentials.output["client_id"]
+  client_secret   = terraform_data.installer_credentials.output["client_secret"]
+  subscription_id = data.azurerm_client_config.current.subscription_id
+  tenant_id       = data.azurerm_client_config.current.tenant_id
 
   features {
     resource_group {


### PR DESCRIPTION
This does the following:

- Uses minimal permissions during cluster provisioning > https://github.com/rh-mobb/terraform-aro-permissions
- Fixes an issue of downloading the latest oc client version causing a glibc conflict
- Removed azuread from required providers (required in the terraform-aro-permissions module)