### PR TITLE
update default version to 4.16.30

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -122,9 +122,9 @@ variable "aro_version" {
   type        = string
   description = <<EOF
   ARO version
-  Default "4.13.23"
+  Default "4.16.30"
   EOF
-  default     = "4.13.23"
+  default     = "4.16.30"
 }
 
 variable "acr_private" {


### PR DESCRIPTION
updated the default version to 4.16.30, which is the latest. 

```
$ az aro get-versions --location eastus
[
  "4.14.38",
  "4.15.35",
  "4.16.30"
]
$ 
```
