### PR TITLE
fix: apply merged tags and expand local file paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Comment PR with results
         if: github.event_name == 'pull_request' && always()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/02-locals.tf
+++ b/02-locals.tf
@@ -12,9 +12,21 @@ locals {
   name_prefix = var.cluster_name
 }
 
+# Tags applied to taggable Azure resources.
+# User-provided tags override defaults, while ManagedBy remains consistent.
+locals {
+  tags = merge(
+    {
+      environment = "development"
+      ManagedBy   = "Terraform"
+    },
+    var.tags
+  )
+}
+
 # Pull secret - read from file if path provided, otherwise null
 locals {
-  pull_secret = var.pull_secret_path != null && var.pull_secret_path != "" ? file(var.pull_secret_path) : null
+  pull_secret = var.pull_secret_path != null && var.pull_secret_path != "" ? file(pathexpand(var.pull_secret_path)) : null
 }
 
 # Service principal names for IAM module

--- a/10-network.tf
+++ b/10-network.tf
@@ -5,7 +5,7 @@ module "aro_network" {
 
   name_prefix                    = local.name_prefix
   location                       = var.location
-  tags                           = var.tags
+  tags                           = local.tags
   aro_virtual_network_cidr_block = var.aro_virtual_network_cidr_block
   aro_control_subnet_cidr_block  = var.aro_control_subnet_cidr_block
   aro_machine_subnet_cidr_block  = var.aro_machine_subnet_cidr_block

--- a/30-jumphost.tf
+++ b/30-jumphost.tf
@@ -41,7 +41,7 @@ resource "azurerm_public_ip" "jumphost_pip" {
   location            = module.aro_network.location
   allocation_method   = "Static"
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "azurerm_network_interface" "jumphost_nic" {
@@ -58,7 +58,7 @@ resource "azurerm_network_interface" "jumphost_nic" {
     public_ip_address_id          = azurerm_public_ip.jumphost_pip[0].id
   }
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "azurerm_network_security_group" "jumphost_nsg" {
@@ -79,7 +79,7 @@ resource "azurerm_network_security_group" "jumphost_nsg" {
     destination_address_prefix = "*"
   }
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "azurerm_network_interface_security_group_association" "jumphost_association" {
@@ -134,5 +134,5 @@ resource "azurerm_linux_virtual_machine" "jumphost_vm" {
     ]
   }
 
-  tags = var.tags
+  tags = local.tags
 }

--- a/40-acr.tf
+++ b/40-acr.tf
@@ -16,6 +16,7 @@ resource "azurerm_private_dns_zone" "dns" {
   count               = var.acr_private ? 1 : 0
   name                = "privatelink.azurecr.io"
   resource_group_name = module.aro_network.resource_group_name
+  tags                = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "dns_link" {
@@ -25,6 +26,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "dns_link" {
   private_dns_zone_name = azurerm_private_dns_zone.dns[0].name
   virtual_network_id    = module.aro_network.virtual_network_id
   registration_enabled  = false
+  tags                  = local.tags
 }
 
 resource "random_string" "acr" {
@@ -43,6 +45,7 @@ resource "azurerm_container_registry" "acr" {
   sku                           = "Premium"
   admin_enabled                 = true
   public_network_access_enabled = false
+  tags                          = local.tags
 }
 
 resource "azurerm_private_endpoint" "acr" {
@@ -51,6 +54,7 @@ resource "azurerm_private_endpoint" "acr" {
   location            = module.aro_network.location
   resource_group_name = module.aro_network.resource_group_name
   subnet_id           = azurerm_subnet.private_endpoint_subnet[0].id
+  tags                = local.tags
 
   private_dns_zone_group {
     name = "acr-zonegroup"

--- a/50-cluster.tf
+++ b/50-cluster.tf
@@ -23,7 +23,7 @@ resource "azurerm_redhat_openshift_cluster" "cluster" {
   name                = var.cluster_name
   location            = module.aro_network.location
   resource_group_name = module.aro_network.resource_group_name
-  tags                = var.tags
+  tags                = local.tags
 
   lifecycle {
     # Ensure cluster is replaced before dependent resources during updates
@@ -88,7 +88,7 @@ module "aro_cluster_azapi" {
   resource_group_name         = module.aro_network.resource_group_name
   managed_resource_group_name = "${module.aro_network.resource_group_name}-managed"
   location                    = module.aro_network.location
-  tags                        = var.tags
+  tags                        = local.tags
 
   domain        = local.domain
   aro_version   = local.aro_version

--- a/modules/aro-network/egress.tf
+++ b/modules/aro-network/egress.tf
@@ -34,6 +34,7 @@ resource "azurerm_firewall" "firewall" {
   resource_group_name = azurerm_resource_group.main.name
   sku_name            = "AZFW_VNet"
   sku_tier            = "Standard"
+  tags                = var.tags
 
   ip_configuration {
     name                 = "${var.name_prefix}-fw-ip-config"


### PR DESCRIPTION
## Summary

Rebased version of #41 (originally authored by @diana-sari), updated to work with the restructured codebase after #40 merged.

- Add `local.tags` to merge default tags (`environment = "development"`, `ManagedBy = "Terraform"`) with user-provided `var.tags`, ensuring documented defaults are consistently applied
- Pass `local.tags` at all module call sites and direct resources (network, jumphost, ACR, cluster)
- Add previously missing `tags` to `azurerm_firewall` inside `modules/aro-network/egress.tf` (using `var.tags` — correct for module context)
- Use `pathexpand()` when reading the pull secret and jumphost SSH key files so `~` paths work reliably — preserved via `local.jumphost_ssh_public_key_content` / `local.jumphost_ssh_private_key_content` locals added in #40
- Add `continue-on-error: true` to the PR comment CI step so a comment failure doesn't block the workflow

## Conflict resolution vs #41

| File | Resolution |
|---|---|
| `10-network.tf` | Kept module call structure from #40; changed `tags = var.tags` → `local.tags` |
| `20-iam.tf` | Kept HEAD (new `aro_mi_rbac` module); dropped stale `tags` hunk targeting removed `aro_managed_identity_permissions` |
| `30-jumphost.tf` | Kept `local.jumphost_ssh_*_content` locals from #40 (supports auto-generated keys); `tags = local.tags` preserved |
| `40-acr.tf` | Kept `module.aro_network.*` refs; added missing `tags = local.tags` to `azurerm_private_dns_zone` |
| `50-cluster.tf` | Kept module refs + AzAPI path from #40; applied `local.tags` to both SP and AzAPI cluster paths; dropped obsolete ARM template hunk |
| `modules/aro-network/egress.tf` | Used `var.tags` (correct for module scope); added missing `tags` to `azurerm_firewall` |

## Test plan

- [ ] `terraform fmt -check` passes
- [ ] `terraform validate` passes
- [ ] SP path: resources receive `ManagedBy = "Terraform"` and user tags merged correctly
- [ ] MI path: `module.aro_cluster_azapi` receives `local.tags`
- [ ] `~`-prefixed pull secret and SSH key paths resolve correctly

Made with [Cursor](https://cursor.com)